### PR TITLE
Fix merge_plists script path handling

### DIFF
--- a/src/Applications/iOSApplication/merge_skadnetworkitems_plists.py
+++ b/src/Applications/iOSApplication/merge_skadnetworkitems_plists.py
@@ -27,17 +27,20 @@ def merge_plists(base, patches, output_path):
         elif isinstance(plist_patch, list):
             plist_base['SKAdNetworkItems'] = plist_base.get('SKAdNetworkItems', []) + [item for item in plist_patch if item not in plist_base.get('SKAdNetworkItems', [])]
 
-    os.makedirs(os.path.dirname(output_path), exist_ok=True)
+    output_dir = os.path.dirname(output_path)
+    if output_dir:
+        os.makedirs(output_dir, exist_ok=True)
 
     with open(output_path, 'wb') as f:
         plistlib.dump(plist_base, f)
 
-if len(sys.argv) < 4:
-    print("Usage: merge_plists.py <base_plist> <patch_plists> <output_plist>")
-    sys.exit(1)
+if __name__ == "__main__":
+    if len(sys.argv) < 4:
+        print("Usage: merge_plists.py <base_plist> <patch_plists> <output_plist>")
+        sys.exit(1)
 
-base = sys.argv[1]
-patches = sys.argv[2:-1]
-total = sys.argv[-1]
+    base = sys.argv[1]
+    patches = sys.argv[2:-1]
+    total = sys.argv[-1]
 
-merge_plists(base, patches, total)
+    merge_plists(base, patches, total)


### PR DESCRIPTION
## Summary
- fix path creation logic in merge_skadnetworkitems_plists.py
- guard entry point with `if __name__ == '__main__'`

## Testing
- `python3 -m py_compile src/Applications/iOSApplication/merge_skadnetworkitems_plists.py`


------
https://chatgpt.com/codex/tasks/task_e_683f4fd74534832088743cb5f48f4aa2