### PR TITLE
Add Sentry logger for Apple and Win32 plugins

### DIFF
--- a/src/Plugins/AppleSentryPlugin/AppleSentryLogger.h
+++ b/src/Plugins/AppleSentryPlugin/AppleSentryLogger.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include "Kernel/LoggerBase.h"
+
+namespace Mengine
+{
+    //////////////////////////////////////////////////////////////////////////
+    class AppleSentryLogger
+        : public LoggerBase
+    {
+    public:
+        AppleSentryLogger();
+        ~AppleSentryLogger() override;
+
+    protected:
+        bool _initializeLogger() override;
+        void _finalizeLogger() override;
+
+    protected:
+        void _log( const LoggerRecordInterfacePtr & _record ) override;
+    };
+    //////////////////////////////////////////////////////////////////////////
+    typedef IntrusivePtr<AppleSentryLogger, LoggerInterface> AppleSentryLoggerPtr;
+    //////////////////////////////////////////////////////////////////////////
+}

--- a/src/Plugins/AppleSentryPlugin/AppleSentryLogger.mm
+++ b/src/Plugins/AppleSentryPlugin/AppleSentryLogger.mm
@@ -58,8 +58,18 @@ namespace Mengine
         NSString * nsMessage = [NSString stringWithUTF8String:message.data];
         NSString * nsCategory = [NSString stringWithUTF8String:message.category];
         NSString * nsThread = [NSString stringWithUTF8String:message.thread.c_str()];
-        NSString * nsFile = message.file != nullptr ? [NSString stringWithUTF8String:message.file] : nil;
-        NSString * nsFunction = message.function != nullptr ? [NSString stringWithUTF8String:message.function] : nil;
+
+        NSString * nsFile = nil;
+        if( message.file != nullptr && message.file[0] != '\0' )
+        {
+            nsFile = [NSString stringWithUTF8String:message.file];
+        }
+
+        NSString * nsFunction = nil;
+        if( message.function != nullptr && message.function[0] != '\0' )
+        {
+            nsFunction = [NSString stringWithUTF8String:message.function];
+        }
 
         SentryLevel level = s_getSentryLevel( message.level );
 
@@ -71,16 +81,16 @@ namespace Mengine
             if( nsFile != nil )
             {
                 [scope setExtraValue:nsFile forKey:@"log.file"];
+
+                if( message.line != 0 )
+                {
+                    [scope setExtraValue:@(message.line) forKey:@"log.line"];
+                }
             }
 
             if( nsFunction != nil )
             {
                 [scope setExtraValue:nsFunction forKey:@"log.function"];
-            }
-
-            if( message.line != 0 )
-            {
-                [scope setExtraValue:@(message.line) forKey:@"log.line"];
             }
         }];
     }

--- a/src/Plugins/AppleSentryPlugin/AppleSentryLogger.mm
+++ b/src/Plugins/AppleSentryPlugin/AppleSentryLogger.mm
@@ -1,0 +1,88 @@
+#include "AppleSentryLogger.h"
+
+#include "Interface/LoggerRecordInterface.h"
+#include "Kernel/LoggerMessage.h"
+
+#import <Sentry/Sentry.h>
+
+namespace Mengine
+{
+    //////////////////////////////////////////////////////////////////////////
+    AppleSentryLogger::AppleSentryLogger()
+    {
+    }
+    //////////////////////////////////////////////////////////////////////////
+    AppleSentryLogger::~AppleSentryLogger()
+    {
+    }
+    //////////////////////////////////////////////////////////////////////////
+    bool AppleSentryLogger::_initializeLogger()
+    {
+        return true;
+    }
+    //////////////////////////////////////////////////////////////////////////
+    void AppleSentryLogger::_finalizeLogger()
+    {
+        //Empty
+    }
+    //////////////////////////////////////////////////////////////////////////
+    static SentryLevel s_getSentryLevel( ELoggerLevel _level )
+    {
+        switch( _level )
+        {
+        case LM_FATAL:
+            return kSentryLevelFatal;
+        case LM_ERROR:
+            return kSentryLevelError;
+        case LM_WARNING:
+            return kSentryLevelWarning;
+        case LM_INFO:
+        case LM_MESSAGE:
+        case LM_MESSAGE_RELEASE:
+            return kSentryLevelInfo;
+        case LM_DEBUG:
+        case LM_VERBOSE:
+            return kSentryLevelDebug;
+        default:
+            break;
+        }
+
+        return kSentryLevelInfo;
+    }
+    //////////////////////////////////////////////////////////////////////////
+    void AppleSentryLogger::_log( const LoggerRecordInterfacePtr & _record )
+    {
+        LoggerMessage message;
+        _record->getMessage( &message );
+
+        NSString * nsMessage = [NSString stringWithUTF8String:message.data];
+        NSString * nsCategory = [NSString stringWithUTF8String:message.category];
+        NSString * nsThread = [NSString stringWithUTF8String:message.thread.c_str()];
+        NSString * nsFile = message.file != nullptr ? [NSString stringWithUTF8String:message.file] : nil;
+        NSString * nsFunction = message.function != nullptr ? [NSString stringWithUTF8String:message.function] : nil;
+
+        SentryLevel level = s_getSentryLevel( message.level );
+
+        [SentrySDK captureMessage:nsMessage withScope:^(SentryScope * _Nonnull scope) {
+            scope.level = level;
+            [scope setExtraValue:nsCategory forKey:@"log.category"];
+            [scope setExtraValue:nsThread forKey:@"log.thread"];
+
+            if( nsFile != nil )
+            {
+                [scope setExtraValue:nsFile forKey:@"log.file"];
+            }
+
+            if( nsFunction != nil )
+            {
+                [scope setExtraValue:nsFunction forKey:@"log.function"];
+            }
+
+            if( message.line != 0 )
+            {
+                [scope setExtraValue:@(message.line) forKey:@"log.line"];
+            }
+        }];
+    }
+    //////////////////////////////////////////////////////////////////////////
+}

--- a/src/Plugins/AppleSentryPlugin/AppleSentryService.h
+++ b/src/Plugins/AppleSentryPlugin/AppleSentryService.h
@@ -5,6 +5,7 @@
 #include "Kernel/ServiceBase.h"
 #include "Kernel/AssertionLevel.h"
 #include "Kernel/ErrorLevel.h"
+#include "Interface/LoggerInterface.h"
 
 namespace Mengine
 {
@@ -23,6 +24,9 @@ namespace Mengine
         void notifyCreateApplication_();
         void notifyAssertion_( const Char * _category, EAssertionLevel _level, const Char * _test, const Char * _file, int32_t _line, const Char * _message );
         void notifyError_( const Char * _category, EErrorLevel _level, const Char * _file, int32_t _line, const Char * _message );
-        void notifyEngineStop_();     
+        void notifyEngineStop_();
+
+    protected:
+        LoggerInterfacePtr m_logger;
     };
 }

--- a/src/Plugins/AppleSentryPlugin/CMakeLists.txt
+++ b/src/Plugins/AppleSentryPlugin/CMakeLists.txt
@@ -6,9 +6,11 @@ src
 
     AppleSentryPlugin.h
     AppleSentryPlugin.mm
-    
+
     AppleSentryService.h
     AppleSentryService.mm
+    AppleSentryLogger.h
+    AppleSentryLogger.mm
 )
 
 if(MENGINE_TARGET_IOS)

--- a/src/Plugins/Win32SentryPlugin/CMakeLists.txt
+++ b/src/Plugins/Win32SentryPlugin/CMakeLists.txt
@@ -7,9 +7,11 @@ src
     Win32SentryPlugin.h
     Win32SentryPlugin.def
     Win32SentryPlugin.cpp
-    
+
     Win32SentryService.h
     Win32SentryService.cpp
+    Win32SentryLogger.h
+    Win32SentryLogger.cpp
 )
 
 add_definitions(-DSENTRY_BUILD_STATIC)

--- a/src/Plugins/Win32SentryPlugin/Win32SentryLogger.cpp
+++ b/src/Plugins/Win32SentryPlugin/Win32SentryLogger.cpp
@@ -63,19 +63,19 @@ namespace Mengine
         sentry_value_set_by_key( extra, "log.category", sentry_value_new_string( message.category ) );
         sentry_value_set_by_key( extra, "log.thread", sentry_value_new_string( message.thread.c_str() ) );
 
-        if( message.file != nullptr )
+        if( message.file != nullptr && message.file[0] != '\0' )
         {
             sentry_value_set_by_key( extra, "log.file", sentry_value_new_string( message.file ) );
+
+            if( message.line != 0 )
+            {
+                sentry_value_set_by_key( extra, "log.line", sentry_value_new_int32( message.line ) );
+            }
         }
 
-        if( message.function != nullptr )
+        if( message.function != nullptr && message.function[0] != '\0' )
         {
             sentry_value_set_by_key( extra, "log.function", sentry_value_new_string( message.function ) );
-        }
-
-        if( message.line != 0 )
-        {
-            sentry_value_set_by_key( extra, "log.line", sentry_value_new_int32( message.line ) );
         }
 
         sentry_value_set_by_key( event, "extra", extra );

--- a/src/Plugins/Win32SentryPlugin/Win32SentryLogger.cpp
+++ b/src/Plugins/Win32SentryPlugin/Win32SentryLogger.cpp
@@ -1,0 +1,86 @@
+#include "Win32SentryLogger.h"
+
+#include "Interface/LoggerRecordInterface.h"
+#include "Kernel/LoggerMessage.h"
+
+#include "sentry.h"
+
+namespace Mengine
+{
+    //////////////////////////////////////////////////////////////////////////
+    Win32SentryLogger::Win32SentryLogger()
+    {
+    }
+    //////////////////////////////////////////////////////////////////////////
+    Win32SentryLogger::~Win32SentryLogger()
+    {
+    }
+    //////////////////////////////////////////////////////////////////////////
+    bool Win32SentryLogger::_initializeLogger()
+    {
+        return true;
+    }
+    //////////////////////////////////////////////////////////////////////////
+    void Win32SentryLogger::_finalizeLogger()
+    {
+        //Empty
+    }
+    //////////////////////////////////////////////////////////////////////////
+    static sentry_level_t s_getSentryLevel( ELoggerLevel _level )
+    {
+        switch( _level )
+        {
+        case LM_FATAL:
+            return SENTRY_LEVEL_FATAL;
+        case LM_ERROR:
+            return SENTRY_LEVEL_ERROR;
+        case LM_WARNING:
+            return SENTRY_LEVEL_WARNING;
+        case LM_INFO:
+        case LM_MESSAGE:
+        case LM_MESSAGE_RELEASE:
+            return SENTRY_LEVEL_INFO;
+        case LM_DEBUG:
+        case LM_VERBOSE:
+            return SENTRY_LEVEL_DEBUG;
+        default:
+            break;
+        }
+
+        return SENTRY_LEVEL_INFO;
+    }
+    //////////////////////////////////////////////////////////////////////////
+    void Win32SentryLogger::_log( const LoggerRecordInterfacePtr & _record )
+    {
+        LoggerMessage message;
+        _record->getMessage( &message );
+
+        sentry_level_t level = s_getSentryLevel( message.level );
+
+        sentry_value_t event = sentry_value_new_message_event( level, "log", message.data );
+
+        sentry_value_t extra = sentry_value_new_object();
+        sentry_value_set_by_key( extra, "log.category", sentry_value_new_string( message.category ) );
+        sentry_value_set_by_key( extra, "log.thread", sentry_value_new_string( message.thread.c_str() ) );
+
+        if( message.file != nullptr )
+        {
+            sentry_value_set_by_key( extra, "log.file", sentry_value_new_string( message.file ) );
+        }
+
+        if( message.function != nullptr )
+        {
+            sentry_value_set_by_key( extra, "log.function", sentry_value_new_string( message.function ) );
+        }
+
+        if( message.line != 0 )
+        {
+            sentry_value_set_by_key( extra, "log.line", sentry_value_new_int32( message.line ) );
+        }
+
+        sentry_value_set_by_key( event, "extra", extra );
+
+        sentry_capture_event( event );
+    }
+    //////////////////////////////////////////////////////////////////////////
+}

--- a/src/Plugins/Win32SentryPlugin/Win32SentryLogger.h
+++ b/src/Plugins/Win32SentryPlugin/Win32SentryLogger.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include "Kernel/LoggerBase.h"
+
+namespace Mengine
+{
+    //////////////////////////////////////////////////////////////////////////
+    class Win32SentryLogger
+        : public LoggerBase
+    {
+    public:
+        Win32SentryLogger();
+        ~Win32SentryLogger() override;
+
+    protected:
+        bool _initializeLogger() override;
+        void _finalizeLogger() override;
+
+    protected:
+        void _log( const LoggerRecordInterfacePtr & _record ) override;
+    };
+    //////////////////////////////////////////////////////////////////////////
+    typedef IntrusivePtr<Win32SentryLogger, LoggerInterface> Win32SentryLoggerPtr;
+    //////////////////////////////////////////////////////////////////////////
+}

--- a/src/Plugins/Win32SentryPlugin/Win32SentryService.h
+++ b/src/Plugins/Win32SentryPlugin/Win32SentryService.h
@@ -28,5 +28,6 @@ namespace Mengine
 
     protected:
         LoggerInterfacePtr m_sentryLogger;
+        LoggerInterfacePtr m_logger;
     };
 }


### PR DESCRIPTION
## Summary
- Add `AppleSentryLogger` and register it within `AppleSentryService`
- Add `Win32SentryLogger` to forward engine logs to Sentry and register/unregister via `Win32SentryService`
- Include new logger sources in Apple and Win32 Sentry plugin builds

## Testing
- `cmake -S . -B build` *(fails: The source directory `/workspace/Mengine` does not appear to contain CMakeLists.txt)*
- `./gradlew -p gradle/plugins/Sentry assemble` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b181c8cbfc8320b9b5c3ae05cd23d0